### PR TITLE
SME feedback

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,9 +31,8 @@ Learn how to acknowledge messages using MicroProfile Reactive Messaging.
 
 == What you'll learn
 
-MicroProfile Reactive Messaging provides an easy way to handle messages in applications that process streams of events,
-and ensure that these messages are not lost in the event of a system failure by using the concept of acknowledgement.
-Acknowledgement differentiates between a message that
+Acknowledgements are a key concept in MicroProfile Reactive Messaging which ensure that messages are not lost in the
+event of a system failure. Acknowledgement differentiates between a message that
 has been delivered to the target service, and a message that has been processed and completed. Every message that gets sent
 must be acknowledged. By differentiating the two, any messages that have been delivered but not acknowledged due to a
 system failure can be sent again.
@@ -111,9 +110,18 @@ Here is a breakdown of the four acknowledgement strategies:
 
 == Implementing the MANUAL acknowledgement strategy
 
-The `inventory` service sends a system property request to the `system` service, but does not verify if the system
-property is valid, therefore the verification is done in the `system` service. The message acknowledgement is handled
-according to whether the system property request is valid or not.
+The `system` service contains the [hotspot=sendProperty file=1]`sendProperty` method which receives property requests
+from the `inventory` service. For each property request, if the property being requested is valid then it produces a
+property response with the value of the property. However, if the requested property doesn't exist, the request is ignored
+and no property response is produced.
+
+There is a key difference here, in the case where a property response is produced, the request is not finished processing
+until the response has been sent and safely stored, and it is only then that the incoming message should be acknowledged.
+However, in the case where the property requested doesn't exist, the method has already finished processing the request
+message so the message needs to be acknowledged immediately.
+
+This situation where a message either needs to be acknowledged immediately or some time later is one of the cases where
+the `MANUAL` acknowledgement strategy would be beneficial.
 
 Ensure that you are in the `start` directory.
 

--- a/README.adoc
+++ b/README.adoc
@@ -203,8 +203,8 @@ include::{common-includes}/os-tabs.adoc[]
 
 == Testing the application
 
-Wait for the services to become available. After the services are up and running, you can access the
-application by making a GET request to the `/systems` endpoint of the `inventory` service.
+After the application is up and running, you can access the application by making a GET request to the `/systems` endpoint
+of the `inventory` service.
 
 Visit the http://localhost:9085/inventory/systems[^] URL to access the inventory microservice. You see the CPU `systemLoad`
 property for all the systems:
@@ -224,29 +224,30 @@ You can revisit the http://localhost:9085/inventory/systems[^] URL after a while
 property for the systems changed.
 
 Make a `PUT` request on the `\http://localhost:9085/inventory/data` URL to add the value of a particular system
-property to the set of existing properties.
+property to the set of existing properties. For example, run the following `curl` command:
 
-For example :
+include::{common-includes}/os-tabs.adoc[]
 
-The `PUT` request with the `os.name` system property in the request body on the `\http://localhost:9085/inventory/data`
-URL will add the `os.name` system property for your system.
-
-Make a `PUT` request to the service by using `curl`:
-
+[.tab_content.mac_section.linux_section]
+--
 [role=command]
 ```
 curl -X PUT -d "os.name" http://localhost:9085/inventory/data --header "Content-Type:text/plain"
 ```
+--
 
-If the `curl` command is unavailable, then use https://www.getpostman.com/[Postman^]. Postman enables you
-to make requests using a graphical interface. To make a request with Postman, enter `\http://localhost:9085/inventory/systems`
-into the URL bar and change the request from `GET` to `PUT`. Go to the `Body` tab and enter the `os.name` value under
-raw category. Click the blue `Send` button to make the request.
+[.tab_content.windows_section]
+--
+If `curl` is unavailable on your computer, use another client such as https://www.getpostman.com/[Postman^],
+which allows requests to be made with a graphical interface.
+--
 
-Behind the scenes, the `inventory` service sends a message containing the requested system property to the `system` service.
-The `inventory` service then waits until the message has been acknowledged before sending a response back.
+In this example, the `PUT` request with the `os.name` system property in the request body on the `\http://localhost:9085/inventory/data`
+URL adds the `os.name` system property for your system. The `inventory` service sends a message containing the requested
+system property to the `system` service. The `inventory` service then waits until the message has been acknowledged
+before sending a response back.
 
-After sending the request you see the following output:
+You see the following output:
 
 [source, role="no_copy"]
 ----
@@ -255,8 +256,8 @@ Request successful for the os.name property
 
 The above response is confirmation that the sent request message has been acknowledged.
 
-You can revisit the http://localhost:9085/inventory/systems[^] URL and see the `os.name` system property value in addition
-to the previous values:
+You can revisit the http://localhost:9085/inventory/systems[^] URL and see the `os.name` system property value is now
+included with the previous values:
 
 [source, role='no_copy']
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -73,42 +73,26 @@ SystemService.java
 include::finish/system/src/main/java/io/openliberty/guides/system/SystemService.java[]
 ----
 
-MicroProfile Reactive Messaging consists of four acknowledgement strategies: `NONE`, `PRE_PROCESSING`, `POST_PROCESSING`,
-and `MANUAL`. Acknowledging messages is required in reactive applications. Messages are either acknowledged explicitly, or
-implicitly by the MicroProfile Reactive Messaging implementation.
+Acknowledging messages is required in reactive applications. Messages are either acknowledged explicitly, or
+implicitly by the MicroProfile Reactive Messaging implementation. Acknowledgement for the incoming messages is controlled
+by the `@Acknowledgment` annotation in the MicroProfile Reactive Messaging specification. If the `@Acknowledgement`
+annotation is not defined explicitly, the default acknowledgement strategy applies, and depends on the method signature.
+Only methods that receive incoming messages and are annotated with `@Incoming` need to acknowledge messages, methods
+that are only annotated with `@Outgoing` methods do not support acknowledgement.
 
-Acknowledgement for the incoming messages is controlled by the `@Acknowledgment` annotation in the MicroProfile Reactive
-Messaging specification. If the `@Acknowledgement` annotation is not defined explicitly, the default acknowledgement
-strategy applies, and depends on the method signature. Only methods that receive incoming messages and are annotated with
-`@Incoming` need to acknowledge messages, methods that are only annotated with `@Outgoing` methods do not support
-acknowledgement.
-
-Different defaults and supported acknowledgement for each supported signature could be found at the
-https://download.eclipse.org/microprofile/microprofile-reactive-messaging-1.0/microprofile-reactive-messaging-spec.html#_message_acknowledgement[Messaging acknowledgement^]
+Different strategy defaults and supported acknowledgement for each supported signature could be found at the
+https://openliberty.io/docs/latest/reference/javadoc/microprofile-3.3-javadoc.html#package=org/eclipse/microprofile/reactive/messaging/package-frame.html&class=overview-summary.html[MicroProfile Reactive Messaging Javadoc^]
 table of the specification.
 
-Here is a breakdown of the four acknowledgement strategies:
+By default, all of the methods that require acknowledging messages are assigned the `POST_PROCESSING` strategy. If the
+acknowledgement strategy is set to POST_PROCESSING, the Reactive Messaging implementation will acknowledge the message
+depending on if the annotated method emits data:
 
-[cols="30, 100", options="header"]
-|===
-| *Strategy*        | *Description*
-| None              | No acknowledgment will be performed. The `NONE` strategy may be used for the protocols that do not
-                        support message acknowledgment.
-| Pre-processing    | The message is acknowledged before the method processes the received message. Methods that use the
-                        `PRE_PROCESSING` or `POST_PROCESSING` acknowledgement strategy rely on the MicroProfile Reactive
-                        Messaging implementation of said strategies.
-| Post-processing   | If the acknowledgement strategy is set to `POST_PROCESSING`, the Reactive Messaging implementation
-                        will acknowledge the message depending on if the annotated method emits data. If the method emits
-                        data, the incoming message will be acknowledged once the outgoing message is acknowledged. If the
-                        method does not emit data, the incoming message will be acknowledged once the method or processing
-                        completes.
-| Manual            | The source code is responsible for the acknowledgement, typically by using the `Message.ack()` method.
-                        `MANUAL` acknowledgement is useful for when the required acknowledgement can not be accomplished
-                        by any other existing Reactive Messaging implementation, and is often used when the incoming message
-                        should be acknowledged after the outgoing message is acknowledged.
-|===
+    1. If the method emits data, the incoming message will be acknowledged once the outgoing message is acknowledged.
+    2. If the method does not emit data, the incoming message will be acknowledged once the method or processing completes.
 
-== Implementing the MANUAL acknowledgement strategy
+The acknowledgement strategy to use for a method depends on the use case of said method. The `system` service contains
+a method which defaults to the `POST_PROCESSING` strategy. This is insufficient and does not produce the desired behaviour.
 
 The `system` service contains the [hotspot=sendProperty file=1]`sendProperty` method which receives property requests
 from the `inventory` service. For each property request, if the property being requested is valid then it produces a
@@ -122,6 +106,8 @@ message so the message needs to be acknowledged immediately.
 
 This situation where a message either needs to be acknowledged immediately or some time later is one of the cases where
 the `MANUAL` acknowledgement strategy would be beneficial.
+
+== Implementing the MANUAL acknowledgement strategy
 
 Ensure that you are in the `start` directory.
 
@@ -146,13 +132,6 @@ type `String`, instead of just a string, to enable acknowledgement. Then, the me
         the incoming message when the sent message has been acknowledged.
 
 == Waiting for a message to be acknowledged
-
-// file 0
-InventoryResource.java
-[source, Java, linenums, role='code_column hide_tags=copyright']
-----
-include::finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java[]
-----
 
 The `inventory` service contains an endpoint that accepts `PUT` requests. When a `PUT` request is made to the `inventory`
 service with a request body that contains a system property, the `inventory` service will send a message to the `system`

--- a/README.adoc
+++ b/README.adoc
@@ -60,17 +60,10 @@ include::{common-includes}/gitclone.adoc[]
 == MicroProfile Reactive Messaging Acknowledgement Strategies
 
 // file 0
-InventoryResource.java
+start/SystemService.java
 [source, Java, linenums, role='code_column hide_tags=copyright']
 ----
-include::finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java[]
-----
-
-// file 1
-SystemService.java
-[source, Java, linenums, role='code_column hide_tags=copyright']
-----
-include::finish/system/src/main/java/io/openliberty/guides/system/SystemService.java[]
+include::start/system/src/main/java/io/openliberty/guides/system/SystemService.java[]
 ----
 
 Acknowledging messages is required in reactive applications. Messages are either acknowledged explicitly, or
@@ -84,7 +77,7 @@ Different strategy defaults and supported acknowledgement for each supported sig
 https://openliberty.io/docs/latest/reference/javadoc/microprofile-3.3-javadoc.html#package=org/eclipse/microprofile/reactive/messaging/package-frame.html&class=overview-summary.html[MicroProfile Reactive Messaging Javadoc^].
 
 By default, all of the methods that require acknowledging messages are assigned the `POST_PROCESSING` strategy. If the
-acknowledgement strategy is set to POST_PROCESSING, the Reactive Messaging implementation will acknowledge the message
+acknowledgement strategy is set to `POST_PROCESSING`, the Reactive Messaging implementation will acknowledge the message
 depending on if the annotated method emits data:
 
     1. If the method emits data, the incoming message will be acknowledged once the outgoing message is acknowledged.
@@ -93,10 +86,11 @@ depending on if the annotated method emits data:
 The acknowledgement strategy to use for a method depends on the use case of said method. The `system` service contains
 a method which defaults to the `POST_PROCESSING` strategy. This is insufficient and does not produce the desired behaviour.
 
-The `system` service contains the [hotspot=sendProperty file=1]`sendProperty` method which receives property requests
-from the `inventory` service. For each property request, if the property being requested is valid then it produces a
-property response with the value of the property. However, if the requested property doesn't exist, the request is ignored
-and no property response is produced.
+The `system` service contains the [hotspot=sendProperty file=0]`sendProperty` method which receives property requests
+from the `inventory` service. For each property request, if the property being requested is valid then it
+[hotspot=validReturn file=0]`returns` a property response with the value of the property. However, if the requested
+property [hotspot=null file=0]`doesn't exist`, the request is ignored and no property response is
+[hotspot=returnNull file=0]`returned`.
 
 There is a key difference here, in the case where a property response is produced, the request is not finished processing
 until the response has been sent and safely stored, and it is only then that the incoming message should be acknowledged.
@@ -108,29 +102,43 @@ the `MANUAL` acknowledgement strategy would be beneficial.
 
 == Implementing the MANUAL acknowledgement strategy
 
+// file 0
+finish/SystemService.java
+[source, Java, linenums, role='code_column hide_tags=copyright']
+----
+include::finish/system/src/main/java/io/openliberty/guides/system/SystemService.java[]
+----
+
 Ensure that you are in the `start` directory.
 
-[role="code_command hotspot file=1", subs="quotes"]
+[role="code_command hotspot file=0", subs="quotes"]
 ----
 #Replace the `SystemService` class.#
 `system/src/main/java/io/openliberty/guides/system/SystemService.java`
 ----
 
 The changes include implementing a `MANUAL` message acknowledgement strategy that fits the method processing requirements.
-First, the method is annotated with the [hotspot=ackAnnotation file=1]`@Acknowledgment(Acknowledgment.Strategy.MANUAL)`
+First, the method is annotated with the [hotspot=ackAnnotation file=0]`@Acknowledgment(Acknowledgment.Strategy.MANUAL)`
 annotation, and therefore must manually acknowledge the message. Only incoming messages can be acknowledged, so the method
-expects an incoming message. The method parameter is updated to receive a [hotspot=methodSignature file=1]`Message` of
+expects an incoming message. The method parameter is updated to receive a [hotspot=methodSignature file=0]`Message` of
 type `String`, instead of just a string, to enable acknowledgement. Then, the message
-[hotspot=propertyValue file=1]`payload` is extracted and checked for validity. There are two outcomes:
+[hotspot=propertyValue file=0]`payload` is extracted and checked for validity. There are two outcomes:
 
-    1. If the system property is [hotspot=invalid file=1]`invalid`, the method [hotspot=propertyMessageAck file=1]`acknowledges`
-        the incoming message and [hotspot=emptyReactiveStream file=1]`returns` an empty reactive stream. The processing is
+    1. If the system property is [hotspot=invalid file=0]`invalid`, the method [hotspot=propertyMessageAck file=0]`acknowledges`
+        the incoming message and [hotspot=emptyReactiveStream file=0]`returns` an empty reactive stream. The processing is
         complete.
-    2. If the system property is valid, the method creates a [hotspot=returnMessage file=1]`message` with
+    2. If the system property is valid, the method creates a [hotspot=returnMessage file=0]`message` with
         the value of the requested system property, and sends it to the proper channel. The method will only acknowledge
         the incoming message when the sent message has been acknowledged.
 
 == Waiting for a message to be acknowledged
+
+// file 0
+InventoryResource.java
+[source, Java, linenums, role='code_column hide_tags=copyright']
+----
+include::finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java[]
+----
 
 The `inventory` service contains an endpoint that accepts `PUT` requests. When a `PUT` request is made to the `inventory`
 service with a request body that contains a system property, the `inventory` service will send a message to the `system`

--- a/README.adoc
+++ b/README.adoc
@@ -81,8 +81,7 @@ Only methods that receive incoming messages and are annotated with `@Incoming` n
 that are only annotated with `@Outgoing` methods do not support acknowledgement.
 
 Different strategy defaults and supported acknowledgement for each supported signature could be found at the
-https://openliberty.io/docs/latest/reference/javadoc/microprofile-3.3-javadoc.html#package=org/eclipse/microprofile/reactive/messaging/package-frame.html&class=overview-summary.html[MicroProfile Reactive Messaging Javadoc^]
-table of the specification.
+https://openliberty.io/docs/latest/reference/javadoc/microprofile-3.3-javadoc.html#package=org/eclipse/microprofile/reactive/messaging/package-frame.html&class=overview-summary.html[MicroProfile Reactive Messaging Javadoc^].
 
 By default, all of the methods that require acknowledging messages are assigned the `POST_PROCESSING` strategy. If the
 acknowledgement strategy is set to POST_PROCESSING, the Reactive Messaging implementation will acknowledge the message

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -91,7 +91,8 @@ public class InventoryResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.TEXT_PLAIN)
     // tag::USPHeader[]
-    // This method sends a message and returns a CompletionStage which doesn't complete until the message is acknowledged
+    /* This method sends a message and returns a CompletionStage which doesn't
+        complete until the message is acknowledged */
     public CompletionStage<Response> updateSystemProperty(String propertyName) {
     // end::USPHeader[]
         logger.info("updateSystemProperty: " + propertyName);
@@ -104,11 +105,14 @@ public class InventoryResource {
         Message<String> message = Message.of(propertyName,
             // tag::acknowledgeAction[]
             () -> {
-                // This is the ack callback which runs when the outgoing message is acknowledged
-                // When the outgoing message is acknowledged, complete the "result" CompletableFuture
+                /* This is the ack callback which runs when the outgoing
+                    message is acknowledged. When the outgoing message is
+                    acknowledged, complete the "result" CompletableFuture */
                 result.complete(null);
-                // An ack callback has to return a CompletionStage which says when it's complete.
-                // There is no need for anything asynchronous, so a completed CompletionStage is returned to indicate that the work here is done
+                /* An ack callback has to return a CompletionStage which says
+                    when it's complete. There is no need for anything asynchronous,
+                    so a completed CompletionStage is returned to indicate that
+                    the work here is done */
                 return CompletableFuture.completedFuture(null);
             }
             // end::acknowledgeAction[]
@@ -117,8 +121,9 @@ public class InventoryResource {
         // Send the message
         propertyNameEmitter.onNext(message);
         // tag::returnResult[]
-        // Set up what should happen when the message is acknowledged and "result" is completed
-        // When "result" completes, the Response object is created with the status code and message
+        /* Set up what should happen when the message is acknowledged and "result"
+            is completed. When "result" completes, the Response object is created
+            with the status code and message */
         return result.thenApply(a -> Response
                 .status(Response.Status.OK)
                 .entity("Request successful for the " + propertyName + " property\n")

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -90,14 +90,14 @@ public class InventoryResource {
     @Path("/data")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.TEXT_PLAIN)
-    // tag::USPHeader[]
     /* This method sends a message and returns a CompletionStage which doesn't
         complete until the message is acknowledged */
+    // tag::USPHeader[]
     public CompletionStage<Response> updateSystemProperty(String propertyName) {
     // end::USPHeader[]
         logger.info("updateSystemProperty: " + propertyName);
-        // tag::CompletableFuture[]
         // First, create an uncompleted CompletableFuture named "result"
+        // tag::CompletableFuture[]
         CompletableFuture<Void> result = new CompletableFuture<>();
         // end::CompletableFuture[]
 
@@ -120,10 +120,10 @@ public class InventoryResource {
 
         // Send the message
         propertyNameEmitter.onNext(message);
-        // tag::returnResult[]
         /* Set up what should happen when the message is acknowledged and "result"
             is completed. When "result" completes, the Response object is created
             with the status code and message */
+        // tag::returnResult[]
         return result.thenApply(a -> Response
                 .status(Response.Status.OK)
                 .entity("Request successful for the " + propertyName + " property\n")

--- a/finish/system/src/main/java/io/openliberty/guides/system/SystemService.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/SystemService.java
@@ -60,7 +60,6 @@ public class SystemService {
                         osMean.getSystemLoadAverage())));
     }
 
-    // tag::sendProperty[]
     @Incoming("propertyRequest")
     @Outgoing("propertyResponse")
     // tag::ackAnnotation[]
@@ -97,5 +96,4 @@ public class SystemService {
         return ReactiveStreams.of(message);
         // end::returnMessage[]
     }
-    // end::sendProperty[]
 }

--- a/finish/system/src/main/java/io/openliberty/guides/system/SystemService.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/SystemService.java
@@ -60,6 +60,7 @@ public class SystemService {
                         osMean.getSystemLoadAverage())));
     }
 
+    // tag::sendProperty[]
     @Incoming("propertyRequest")
     @Outgoing("propertyResponse")
     // tag::ackAnnotation[]
@@ -96,4 +97,5 @@ public class SystemService {
         return ReactiveStreams.of(message);
         // end::returnMessage[]
     }
+    // end::sendProperty[]
 }

--- a/start/system/src/main/java/io/openliberty/guides/system/SystemService.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/SystemService.java
@@ -56,17 +56,25 @@ public class SystemService {
                         osMean.getSystemLoadAverage())));
     }
 
+    // tag::sendProperty[]
     @Incoming("propertyRequest")
     @Outgoing("propertyResponse")
     public PropertyMessage sendProperty(String propertyName) {
         logger.info("sendProperty: " + propertyName);
         String propertyValue = System.getProperty(propertyName);
+        // tag::null[]
         if (propertyValue == null) {
             logger.warning(propertyName + " is not System property.");
+            // tag::returnNull[]
             return null;
+            // end::returnNull[]
         }
+        // end::null[]
+        // tag::validReturn[]
         return new PropertyMessage(getHostname(),
                 propertyName,
                 System.getProperty(propertyName, "unknown"));
+        // end::validReturn[]
     }
+    // end::sendProperty[]
 }


### PR DESCRIPTION
Addressed #10
- Rewrote the first paragraph to jump into the concept of acknowledgement quickly.
- Rewrote the `MicroProfile Reactive Messaging Acknowledgement Strategies` section completely and removed the table. Started with an explanation of acknowledgement, leads into the default strategies depending on method signature, explains `POST_PROCESSING`, explains why it's not sufficient for the `system` service to lead into the next section that implements the `MANUAL` strategy instead. `NONE` and `PRE_PROCESSING` were not explained, and we decided not to try and explain general best practice, and instead just go into the strategies used in this specific use case and why they're used.
- Added the suggested paragraphs and comments taken from #10 into README and code with slight modifications.
- Rewrote the `Testing the application` section to match the rest integration guide with a focus on the newly implemented acknowledgement features.

Most recent version of the guide can be found here:  http://lgdev1.fyre.ibm.com:4020/guides/microprofile-reactive-messaging-acknowledgement.html